### PR TITLE
Fix low walls being unpaintable while a window was on them

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -189,14 +189,13 @@
 	var/turf/T = get_turf_pixel(src)
 	if(!T)
 		return FALSE
-	for(var/atom/movable/AM in T)
+	for(var/atom/movable/AM as anything in T)
 		if(AM.flags_1 & PREVENT_CLICK_UNDER_1 && AM.density && AM.layer > layer)
 			return TRUE
 	return FALSE
 
 /turf/IsObscured()
-	for(var/item in src)
-		var/atom/movable/AM = item
+	for(var/atom/movable/AM as anything in src)
 		if(AM.flags_1 & PREVENT_CLICK_UNDER_1)
 			return TRUE
 	return FALSE

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -103,6 +103,9 @@
 	if(locate(/obj/structure/low_wall) in get_turf(mover))
 		return TRUE
 
+/obj/structure/low_wall/IsObscured()
+	return //NEVER. This makes paint work LOL
+
 /obj/structure/low_wall/attackby(obj/item/weapon, mob/living/user, params)
 	if(is_top_obstructed())
 		return TRUE


### PR DESCRIPTION
## Changelog

:cl:
fix: Low walls can now be painted while a window is atop them.
/:cl:
