### PR TITLE
Improves SScredits code

### DIFF
--- a/code/controllers/subsystem/credits.dm
+++ b/code/controllers/subsystem/credits.dm
@@ -258,8 +258,9 @@ SUBSYSTEM_DEF(credits)
 		return star
 	if(ismob(star))
 		var/mob/M = star
-		if(M.mind.key && M.client?.prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
-			return "[uppertext(M.mind.key)] as [M.real_name]"
+		var/datum/preferences/prefs = GLOB.preferences_datums[ckey(M.mind.key)]
+		if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
+			return "[uppertext(ckey(M.mind.key))] as [M.real_name]"
 		else
 			return "[uppertext(M.real_name)] as [M.p_them(TRUE) == "Them" ? "Themselves" : "[M.p_them(TRUE)]self"]"
 

--- a/code/controllers/subsystem/credits.dm
+++ b/code/controllers/subsystem/credits.dm
@@ -173,9 +173,10 @@ SUBSYSTEM_DEF(credits)
 
 /datum/controller/subsystem/credits/proc/draft_star()
 	var/mob/living/carbon/human/most_talked
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!H.ckey || H.stat == DEAD)
+	for(var/datum/mind/M as anything in SSticker.minds)
+		if(!M.key || (!M.current || M.current.stat == DEAD || !ishuman(M.current)))
 			continue
+		var/mob/living/carbon/human/H = M.current
 		if(!most_talked || H.talkcount > most_talked.talkcount)
 			most_talked = H
 	star = thebigstar(most_talked)
@@ -193,48 +194,62 @@ SUBSYSTEM_DEF(credits)
 /datum/controller/subsystem/credits/proc/draft_caststring()
 	cast_string = "<h1>CAST:</h1><br><h2>(in order of appearance)</h2><br>"
 	cast_string += "<table class='crewtable'>"
-	var/list/cast = list()
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!H.ckey && !(H.stat == DEAD))
-			continue
-		cast_string += "[H.get_credits_entry()]"
-		cast += H
+	var/list/dead_names = list()
+	var/cast_count
+	for(var/datum/mind/M as anything in SSticker.minds)
+		if(M.key && M.name)
+			if(!M.current || (M.current.stat == DEAD)) //Their body was destroyed or they are simply dead
+				dead_names += M.name
+				continue
+		else
+			continue //The mob was never player controlled/didn't have a name (wtf how)
 
-	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
-		if(!S.ckey)
-			continue
-		cast_string += "[S.get_credits_entry()]"
-		cast += S
+		cast_string += "[M.current.get_credits_entry()]"
+		cast_count++
 
-	if(!length(cast))
+	if(!cast_count)
 		cast_string += "<tr><td class='actorsegue'> Nobody! </td></tr>"
 
 	cast_string += "</table><br>"
 	cast_string += "<div class='disclaimers'>"
 
-	var/list/corpses = list()
-	for(var/datum/mind/M as anything in SSticker.minds)
-		if(!M.key || (M.current in cast))
-			continue
-		if(M.name)
-			corpses += M.name
-	if(corpses.len)
+	if(dead_names.len)
 		var/true_story_bro = "<br>[pick("BASED ON","INSPIRED BY","A RE-ENACTMENT OF")] [pick("A TRUE STORY","REAL EVENTS","THE EVENTS ABOARD [uppertext(station_name())]")]"
-		cast_string += "<h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br>"
+		cast_string += "<h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(dead_names)].<br>"
 	cast_string += "</div><br>"
 
 /mob/living/proc/get_credits_entry()
+	var/datum/preferences/prefs = GLOB.preferences_datums[ckey(mind.key)]
+	var/gender_text
+	switch(gender)
+		if("male")
+			gender_text = "Himself"
+		if("female")
+			gender_text = "Herself"
+		if("neuter")
+			gender_text = "Themself"
+		if("plural")
+			gender_text = "Themselves"
+		else
+			gender_text = "Itself"
+
+	if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
+		return "<tr><td class='actorname'>[uppertext(ckey(mind.key))]</td><td class='actorsegue'> as </td><td class='actorrole'>[name]</td></tr>"
+	else
+		return "<tr><td class='actorname'>[uppertext(name)]</td><td class='actorsegue'> as </td><td class='actorrole'>[gender_text]</td></tr>"
 
 /mob/living/carbon/human/get_credits_entry()
-	if(client?.prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
+	var/datum/preferences/prefs = GLOB.preferences_datums[ckey(mind.key)]
+	if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
 		var/assignment = get_assignment(if_no_id = "", if_no_job = "")
-		return "<tr><td class='actorname'>[uppertext(mind.key)]</td><td class='actorsegue'> as </td><td class='actorrole'>[real_name][assignment == "" ? "" : ", [assignment]"]</td></tr>"
+		return "<tr><td class='actorname'>[uppertext(ckey(mind.key))]</td><td class='actorsegue'> as </td><td class='actorrole'>[real_name][assignment == "" ? "" : ", [assignment]"]</td></tr>"
 	else
-		return "<tr><td class='actorname'>[uppertext(real_name)]</td><td class='actorsegue'> as </td><td class='actorrole'>[p_them(TRUE) == "Them" ? "Themselves" : "[p_them(TRUE)]self"]</td></tr>"
+		return "<tr><td class='actorname'>[uppertext(real_name)]</td><td class='actorsegue'> as </td><td class='actorrole'>[p_them(TRUE) == "Them" ? "Themself" : "[p_them(TRUE)]self"]</td></tr>"
 
 /mob/living/silicon/get_credits_entry()
-	if(client?.prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
-		return "<tr><td class='actorname'>[uppertext(mind.key)]</td><td class='actorsegue'> as </td><td class='actorrole'>[name]</td></tr>"
+	var/datum/preferences/prefs = GLOB.preferences_datums[ckey(mind.key)]
+	if(prefs.read_preference(/datum/preference/toggle/credits_uses_ckey))
+		return "<tr><td class='actorname'>[uppertext(ckey(mind.key))]</td><td class='actorsegue'> as </td><td class='actorrole'>[name]</td></tr>"
 	else
 		return "<tr><td class='actorname'>[uppertext(name)]</td><td class='actorsegue'> as </td><td class='actorrole'>Itself</td></tr>"
 

--- a/code/controllers/subsystem/credits.dm
+++ b/code/controllers/subsystem/credits.dm
@@ -193,31 +193,31 @@ SUBSYSTEM_DEF(credits)
 /datum/controller/subsystem/credits/proc/draft_caststring()
 	cast_string = "<h1>CAST:</h1><br><h2>(in order of appearance)</h2><br>"
 	cast_string += "<table class='crewtable'>"
-	var/cast_num = 0
+	var/list/cast = list()
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(!H.ckey && !(H.stat == DEAD))
 			continue
 		cast_string += "[H.get_credits_entry()]"
-		cast_num++
+		cast += H
 
 	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
 		if(!S.ckey)
 			continue
 		cast_string += "[S.get_credits_entry()]"
-		cast_num++
+		cast += S
 
-	if(!cast_num)
+	if(!length(cast))
 		cast_string += "<tr><td class='actorsegue'> Nobody! </td></tr>"
 
 	cast_string += "</table><br>"
 	cast_string += "<div class='disclaimers'>"
 
 	var/list/corpses = list()
-	for(var/mob/living/carbon/human/H in GLOB.dead_mob_list)
-		if(!H.mind)
+	for(var/datum/mind/M as anything in SSticker.minds)
+		if(!M.key || (M.current in cast))
 			continue
-		if(H.real_name)
-			corpses += H.real_name
+		if(M.name)
+			corpses += M.name
 	if(corpses.len)
 		var/true_story_bro = "<br>[pick("BASED ON","INSPIRED BY","A RE-ENACTMENT OF")] [pick("A TRUE STORY","REAL EVENTS","THE EVENTS ABOARD [uppertext(station_name())]")]"
 		cast_string += "<h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes a couple uses global mob lists to simply `SSticker.minds`. Greatly improves code quality, as well as adds support for multiple mobs per ckey in the credits.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Credits now display all characters a player inhabited during the round.
add: Credits now display gibbed characters as dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
