### PR TITLE
Fixes a gamebreaking zas init bug

### DIFF
--- a/code/__DEFINES/atmospherics/ZAS.dm
+++ b/code/__DEFINES/atmospherics/ZAS.dm
@@ -1,5 +1,5 @@
 ///Enables verbose debugging and the debug overlay. NOTE: Debug Overlay does not report MultiZAS information at this time.
-#define ZASDBG
+//#define ZASDBG
 
 ///Enables multi-Z air movement. Zones do not merge across Z levels.
 #define MULTIZAS

--- a/code/__DEFINES/atmospherics/ZAS.dm
+++ b/code/__DEFINES/atmospherics/ZAS.dm
@@ -1,5 +1,5 @@
 ///Enables verbose debugging and the debug overlay. NOTE: Debug Overlay does not report MultiZAS information at this time.
-//#define ZASDBG
+#define ZASDBG
 
 ///Enables multi-Z air movement. Zones do not merge across Z levels.
 #define MULTIZAS

--- a/code/controllers/subsystem/zas.dm
+++ b/code/controllers/subsystem/zas.dm
@@ -113,6 +113,7 @@ SUBSYSTEM_DEF(zas)
 /datum/controller/subsystem/zas/proc/Reboot()
 	// Stop processing while we rebuild.
 	can_fire = FALSE
+	times_fired = 0 // This is done to prevent the geometry bug explained in connect()
 	next_id = 0 //Reset atmos zone count.
 
 	// Make sure we don't rebuild mid-tick.

--- a/code/controllers/subsystem/zas.dm
+++ b/code/controllers/subsystem/zas.dm
@@ -408,7 +408,11 @@ SUBSYSTEM_DEF(zas)
 	var/space = !B.simulated
 
 	if(!space)
-		if(min(length(A.zone.contents), length(B.zone.contents)) < ZONE_MIN_SIZE || (direct && (equivalent_pressure(A.zone,B.zone) || times_fired == 0)))
+		// Ok. This is super fucking cursed, but, it has to be this way.
+		// Basically, it's possible that during the initial geometry build, a zone can be created in a spot
+		// such that it merges over zone-blocker due to the minimum size requirement being met to merge over blockers.
+		// To fix this, we disable that during the geometry build, which takes place during Initialize()
+		if((times_fired && min(length(A.zone.contents), length(B.zone.contents)) < ZONE_MIN_SIZE) || (direct && equivalent_pressure(A.zone,B.zone)))
 			merge(A.zone,B.zone)
 			return TRUE
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -52,8 +52,6 @@
 /obj/machinery/door/firedoor/LateInitialize()
 	. = ..()
 	set_area(get_area(src))
-	if(loc.z == 2 && loc.y == 124 && (loc.x in list(125, 126, 127)))
-		loc:verbose = TRUE
 
 /obj/machinery/door/firedoor/Destroy()
 	set_area(null)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -22,7 +22,6 @@
 	assemblytype = /obj/structure/firelock_frame
 	armor = list(MELEE = 10, BULLET = 30, LASER = 20, ENERGY = 20, BOMB = 30, BIO = 100, FIRE = 95, ACID = 70)
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
-
 	door_align_type = /obj/machinery/door/firedoor
 
 	align_to_windows = TRUE
@@ -48,15 +47,13 @@
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_FIRE_ALERT, .proc/handle_alert)
-	if(prob(0.004) && icon == 'icons/obj/doors/doorfireglass.dmi')
-		base_icon_state = "sus"
-		desc += " This one looks a bit sus..."
-
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/door/firedoor/LateInitialize()
 	. = ..()
 	set_area(get_area(src))
+	if(loc.z == 2 && loc.y == 124 && (loc.x in list(125, 126, 127)))
+		loc:verbose = TRUE
 
 /obj/machinery/door/firedoor/Destroy()
 	set_area(null)

--- a/code/modules/atmospherics/ZAS/Zone.dm
+++ b/code/modules/atmospherics/ZAS/Zone.dm
@@ -70,6 +70,8 @@ Class Procs:
 	ASSERT(!invalid)
 	ASSERT(istype(T))
 	ASSERT(!TURF_HAS_VALID_ZONE(T))
+
+	T.maptext = name
 #endif
 
 	var/datum/gas_mixture/turf_air = T.return_air()
@@ -92,6 +94,8 @@ Class Procs:
 	ASSERT(istype(T))
 	ASSERT(T.zone == src)
 	soft_assert(T in contents, "Lists are weird broseph")
+
+	T.maptext = null
 #endif
 	if(!T.can_safely_remove_from_zone())
 		INVOKE_ASYNC(src, .proc/rebuild)


### PR DESCRIPTION
See code comment for details.

:cl:
fix: Some oddities with ZAS fixed. Notably on Metastation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
