### PR TITLE
Fixes "Observe Ready" and adds a multitool interaction to vent scrubbers/pumps.

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -8526,7 +8526,7 @@
 "aXN" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -15352,14 +15352,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/security/armory)
-"cbq" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "cbr" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -26189,7 +26181,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+	dir = 8;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -26297,10 +26290,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"etb" = (
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "etH" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/tile/neutral,
@@ -42203,7 +42192,7 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/spawner/random/structure/crate,
 /mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=1,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "A timeless classic.";
 	name = "Kentucky"
 	},
@@ -47688,7 +47677,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Ordnance Test Lab";
 	name = "science camera";
-	network = list("ss13", "rd")
+	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/structure/sign/poster/random/directional/north,
@@ -54741,9 +54730,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"nUs" = (
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
 "nUt" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -54844,13 +54830,6 @@
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/pharmacy)
-"nVA" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-
-/turf/open/floor/iron/dark,
-/area/service/chapel/monastery)
 "nVD" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
@@ -56941,7 +56920,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Ordnance Storage";
 	name = "science camera";
-	network = list("ss13", "rd")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
@@ -60794,7 +60773,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
 	external_pressure_bound = 140;
-	pressure_checks = 0
+	pressure_checks = 0;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -70229,7 +70209,7 @@
 /area/command/bridge)
 "sSj" = (
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("ordnancegas1" = "Burn Chamber", "ordnancegas2" = "Freezer Chamber");
+	atmos_chambers = list("ordnancegas1"="Burn Chamber","ordnancegas2"="Freezer Chamber");
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
@@ -77892,7 +77872,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/beer{
 	desc = "A station exclusive. Consumption may result in seizures, blindness, drunkenness, or even death.";
-	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko = 30);
+	list_reagents = list(/datum/reagent/consumable/ethanol/thirteenloko=30);
 	name = "Kilo-Kocktail";
 	pixel_x = 5;
 	pixel_y = 5
@@ -84261,9 +84241,6 @@
 /obj/machinery/fax_machine,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hop)
-"xFO" = (
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "xFY" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -99418,7 +99395,7 @@ aeu
 har
 pXo
 jpV
-nUs
+iAp
 iAp
 lda
 xXY
@@ -99687,7 +99664,7 @@ mdO
 ksq
 lIN
 anJ
-nVA
+uLm
 jpV
 kzH
 oOQ
@@ -112662,7 +112639,7 @@ eJR
 myt
 oDX
 wWg
-etb
+lmB
 hFd
 xzv
 aaa
@@ -113689,7 +113666,7 @@ acK
 xzv
 htY
 cpF
-xFO
+qga
 lmB
 qga
 iGH
@@ -114932,7 +114909,7 @@ imV
 rqY
 rni
 bZG
-cbq
+voX
 fwx
 ohN
 nRg
@@ -115189,7 +115166,7 @@ xbm
 mzi
 nSd
 oTs
-cbq
+voX
 fwx
 tUl
 gvk
@@ -115703,7 +115680,7 @@ prS
 prS
 nMp
 bZG
-cbq
+voX
 xeC
 jiV
 mTX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10499,15 +10499,6 @@
 	dir = 1
 	},
 /area/engineering/atmos)
-"cMV" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "cMY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -28746,7 +28737,8 @@
 /area/maintenance/port/greater)
 "jrn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+	dir = 1;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -29913,16 +29905,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jMF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "jMP" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -29983,13 +29965,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"jOl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "jOn" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -33401,14 +33376,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar)
-"ldf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "ldP" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/satellite)
@@ -38426,7 +38393,9 @@
 	},
 /area/maintenance/starboard/greater)
 "mNF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	can_hibernate = 0
+	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "mNH" = (
@@ -38898,12 +38867,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/mixing)
-"mUK" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "mUO" = (
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62355,9 +62318,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"vVR" = (
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "vWe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -83142,7 +83102,7 @@ rJv
 rJv
 rJv
 bnM
-jMF
+vlz
 tEv
 alK
 alK
@@ -83399,7 +83359,7 @@ rJv
 rJv
 rJv
 bnM
-jMF
+vlz
 qaR
 ikK
 dWo
@@ -84170,7 +84130,7 @@ rJv
 rJv
 rJv
 bnM
-jMF
+vlz
 sQs
 ikK
 ikK
@@ -93740,7 +93700,7 @@ mQS
 cMS
 hpI
 cMg
-cMV
+jIK
 jIK
 eiR
 mSp
@@ -95279,11 +95239,11 @@ eGg
 cAo
 cLr
 cMg
-cMV
-cMV
+jIK
+jIK
 tHb
-cMV
-cMV
+jIK
+jIK
 ouJ
 cMf
 cQK
@@ -96219,17 +96179,17 @@ dmU
 yej
 mZb
 aHA
-mUK
-mUK
+wGX
+wGX
 nQp
-mUK
-mUK
-mUK
-mUK
+wGX
+wGX
+wGX
+wGX
 cfu
 lpV
-mUK
-mUK
+wGX
+wGX
 hrq
 hlv
 jia
@@ -96476,7 +96436,7 @@ ajx
 adY
 aDB
 aHA
-mUK
+wGX
 aHC
 aHD
 nhM
@@ -96733,7 +96693,7 @@ ece
 cFI
 aHF
 aET
-mUK
+wGX
 aHD
 tSf
 iZa
@@ -103650,7 +103610,7 @@ ghU
 vJs
 rvl
 gYT
-ldf
+eMZ
 eMZ
 dls
 pSI
@@ -103669,7 +103629,7 @@ sTJ
 dqy
 iPs
 tDs
-jOl
+bpa
 tYB
 oUt
 fBu
@@ -108354,7 +108314,7 @@ ghG
 hTd
 jGe
 cgz
-vVR
+iKn
 cgz
 cgz
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17418,7 +17418,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/bluespace_vendor/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bkn" = (
@@ -21567,7 +21566,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "byY" = (
@@ -21835,14 +21833,6 @@
 "bzO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bzX" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bzZ" = (
@@ -26144,10 +26134,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bRv" = (
-/obj/machinery/atmospherics/components/unary/bluespace_sender,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bRx" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/stripes/line{
@@ -29718,7 +29704,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+	dir = 8;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -29727,7 +29714,8 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+	dir = 4;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -34143,7 +34131,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light,
-/obj/machinery/bluespace_vendor/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dBQ" = (
@@ -34738,7 +34725,6 @@
 	},
 /area/maintenance/department/science)
 "egd" = (
-/obj/machinery/power/turbine/turbine_outlet,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "egk" = (
@@ -36222,13 +36208,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fqJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/bluespace_vendor/directional/south,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "frn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -38060,7 +38039,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+	dir = 8;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -38654,14 +38634,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/monastery)
-"hGY" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/bluespace_vendor/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -39543,11 +39515,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"iDX" = (
-/obj/machinery/computer/slot_machine,
-/obj/machinery/bluespace_vendor/directional/north,
-/turf/open/floor/carpet/lone,
-/area/service/bar/atrium)
 "iEJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40094,17 +40061,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"jkQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/bluespace_vendor/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "jlb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41622,9 +41578,6 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "kHY" = (
-/obj/machinery/power/turbine/core_rotor{
-	mapping_id = "main_turbine"
-	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -44284,10 +44237,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/machinery/computer/turbine_computer{
-	dir = 1;
-	mapping_id = "main_turbine"
-	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "njz" = (
@@ -45131,7 +45080,8 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+	dir = 4;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -47472,7 +47422,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "qcR" = (
@@ -48735,15 +48684,6 @@
 /area/service/chapel)
 "rfm" = (
 /obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -48754,7 +48694,6 @@
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
-/obj/machinery/bluespace_vendor/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rgO" = (
@@ -49121,7 +49060,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+	dir = 4;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -50151,7 +50091,8 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+	dir = 8;
+	can_hibernate = 0
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -51515,7 +51456,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/bluespace_vendor/directional/south,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -57277,10 +57217,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"xMg" = (
-/obj/machinery/power/turbine/inlet_compressor,
-/turf/open/floor/engine,
-/area/maintenance/disposal/incinerator)
 "xMQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim{
@@ -79519,7 +79455,7 @@ jsa
 jsa
 jsa
 lmU
-jkQ
+lmU
 pMG
 qdO
 tfS
@@ -86475,7 +86411,7 @@ cqd
 bvn
 cqd
 byt
-bzX
+cqd
 bIi
 wLW
 bCp
@@ -92363,7 +92299,7 @@ aWq
 aXn
 aYl
 aUf
-iDX
+bap
 bbw
 hHG
 jdA
@@ -93124,7 +93060,7 @@ dNA
 ydu
 nLS
 ydu
-hGY
+ydu
 aRd
 lYE
 rpB
@@ -93430,7 +93366,7 @@ ksv
 bOS
 bLc
 bPQ
-bRv
+bWO
 bSe
 bSU
 bPQ
@@ -96195,7 +96131,7 @@ aym
 wLx
 aav
 aQC
-fqJ
+cHR
 aET
 aET
 bPd
@@ -99357,7 +99293,7 @@ aht
 bYw
 atf
 dmB
-xMg
+egd
 kHY
 egd
 wbb

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -351,6 +351,8 @@ SUBSYSTEM_DEF(ticker)
 				player.new_player_panel()
 				continue
 			player.create_character(destination)
+		else if(player.ready == PLAYER_READY_TO_OBSERVE)
+			player.make_me_an_observer(TRUE)
 		else
 			player.new_player_panel()
 		CHECK_TICK

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -121,8 +121,9 @@
 		if(pump_direction & RELEASING) //internal -> external
 			var/transfer_moles = calculate_transfer_moles(air_contents, environment, pressure_delta)
 			var/draw = pump_gas(air_contents, environment, transfer_moles, power_rating)
-			if(draw == -1 && can_hibernate)
-				COOLDOWN_START(src, hibernating, 15 SECONDS)
+			if(draw == -1)
+				if(can_hibernate)
+					COOLDOWN_START(src, hibernating, 15 SECONDS)
 			else if(draw)
 				ATMOS_USE_POWER(draw)
 			update_parents()
@@ -133,8 +134,9 @@
 			//limit flow rate from turfs
 			transfer_moles = min(transfer_moles, environment.total_moles*air_contents.volume/environment.volume)	//group_multiplier gets divided out here
 			var/draw = pump_gas(environment, air_contents, transfer_moles, power_rating)
-			if(draw == -1 && can_hibernate)
-				COOLDOWN_START(src, hibernating, 15 SECONDS)
+			if(draw == -1)
+				if(can_hibernate)
+					COOLDOWN_START(src, hibernating, 15 SECONDS)
 			else if(draw)
 				ATMOS_USE_POWER(draw)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -38,6 +38,9 @@
 	///Radio connection from the air alarm
 	var/radio_filter_in
 
+	///Whether or not this machine can fall asleep. Use a multitool to change.
+	var/can_hibernate = TRUE
+
 /obj/machinery/atmospherics/components/unary/vent_scrubber/New()
 	if(!id_tag)
 		id_tag = SSnetworks.assign_random_name()
@@ -223,7 +226,7 @@
 		for(var/i in 1 to 2)
 			if(scrub(us))
 				should_cooldown = FALSE
-	if(should_cooldown)
+	if(should_cooldown && can_hibernate)
 		COOLDOWN_START(src, hibernating, 15 SECONDS)
 	update_icon_nopipes()
 
@@ -376,6 +379,14 @@
 	pipe_vision_img.plane = ABOVE_HUD_PLANE
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 100, TRUE)
 
+/obj/machinery/atmospherics/components/unary/vent_scrubber/multitool_act(mob/living/user, obj/item/tool)
+	. = ..()
+	can_hibernate = !can_hibernate
+	to_chat(user, span_notice("\The [src] will [can_hibernate ? "now" : "no longer"] sleep to conserve energy."))
+	if(!can_hibernate)
+		COOLDOWN_RESET(src, hibernating)
+
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2
 	piping_layer = 2

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -169,7 +169,7 @@
 	popup.open(FALSE)
 
 //When you cop out of the round (NB: this HAS A SLEEP FOR PLAYER INPUT IN IT)
-/mob/dead/new_player/proc/make_me_an_observer()
+/mob/dead/new_player/proc/make_me_an_observer(skip_check)
 	if(QDELETED(src) || !src.client)
 		ready = PLAYER_NOT_READY
 		return FALSE
@@ -177,9 +177,13 @@
 	var/less_input_message
 	if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP])
 		less_input_message = " - Notice: Observer freelook is currently disabled."
-	// Don't convert this to tgui please, it's way too important
-	var/this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
-	if(QDELETED(src) || !src.client || this_is_like_playing_right != "Yes")
+
+	var/this_is_like_playing_right
+	if(!skip_check)
+		// Don't convert this to tgui please, it's way too important
+		this_is_like_playing_right = alert(usr, "Are you sure you wish to observe? You will not be able to play this round![less_input_message]", "Observe", "Yes", "No")
+
+	if(QDELETED(src) || !src.client || (!skip_check && (this_is_like_playing_right != "Yes")))
 		ready = PLAYER_NOT_READY
 		src << browse(null, "window=playersetup") //closes the player setup window
 		new_player_panel()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the "Observe" button on the new player panel not actually auto-observing on round start.

Using a Multitool on a vent scrubber or pump will toggle it's ability to sleep.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Using a multitool on a vent scrubber/pump toggles it's ability to sleep.
fix: "Observe" on the New Player Panel will now auto-observe on roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
