### PR TITLE
Vacuums now all act like space for heat exchange

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -124,7 +124,7 @@
 		//Restore air flow if we were blocking it (movables with zas_canpass() will need to do this manually if necessary)
 		if(((can_atmos_pass == CANPASS_DENSITY && density) || can_atmos_pass == CANPASS_NEVER) && isturf(loc))
 			can_atmos_pass = CANPASS_ALWAYS
-			update_nearby_tiles()
+			zas_update_loc()
 
 		loc.handle_atom_del(src)
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1201,7 +1201,7 @@
 	sleep(4)
 	set_density(FALSE)
 	flags_1 &= ~PREVENT_CLICK_UNDER_1
-	update_nearby_tiles()
+	zas_update_loc()
 	sleep(1)
 	layer = OPEN_DOOR_LAYER
 	update_icon(ALL, AIRLOCK_OPEN, TRUE)
@@ -1246,12 +1246,12 @@
 	if(air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		update_nearby_tiles()
+		zas_update_loc()
 	sleep(1)
 	if(!air_tight)
 		set_density(TRUE)
 		flags_1 |= PREVENT_CLICK_UNDER_1
-		update_nearby_tiles()
+		zas_update_loc()
 	sleep(4)
 	if(dangerous_close)
 		crush()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -66,7 +66,7 @@
 	else
 		flags_1 &= ~PREVENT_CLICK_UNDER_1
 
-	update_nearby_tiles()
+	zas_update_loc()
 	//doors only block while dense though so we have to use the proc
 	real_explosion_block = explosion_block
 	explosion_block = EXPLOSION_BLOCK_PROC
@@ -173,7 +173,7 @@
 	if(spark_system)
 		qdel(spark_system)
 		spark_system = null
-	update_nearby_tiles()
+	zas_update_loc()
 	return ..()
 
 /obj/machinery/door/zas_canpass(turf/other)
@@ -246,7 +246,7 @@
 		return
 
 /obj/machinery/door/Move()
-	update_nearby_tiles()
+	zas_update_loc()
 	. = ..()
 
 
@@ -432,7 +432,7 @@
 	update_appearance()
 	set_opacity(0)
 	operating = FALSE
-	update_nearby_tiles()
+	zas_update_loc()
 	update_freelook_sight()
 	if(autoclose)
 		autoclose_in(DOOR_CLOSE_WAIT)
@@ -462,7 +462,7 @@
 	if(visible && !glass)
 		set_opacity(1)
 	operating = FALSE
-	update_nearby_tiles()
+	zas_update_loc()
 	update_freelook_sight()
 
 	if(!can_crush)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -61,7 +61,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/machinery/door/window/ComponentInitialize()
 	. = ..()
@@ -75,7 +75,7 @@
 	electronics = null
 	/*var/turf/floor = get_turf(src)
 	floor.air_update_turf(TRUE, FALSE)*/
-	update_nearby_tiles()
+	zas_update_loc()
 	return ..()
 
 /obj/machinery/door/window/update_icon_state()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -73,8 +73,6 @@
 	if(atom_integrity == 0)
 		playsound(src, SFX_SHATTER, 70, TRUE)
 	electronics = null
-	/*var/turf/floor = get_turf(src)
-	floor.air_update_turf(TRUE, FALSE)*/
 	zas_update_loc()
 	return ..()
 
@@ -218,7 +216,6 @@
 	icon_state ="[base_state]open"
 	sleep(10)
 	set_density(FALSE)
-	//air_update_turf(TRUE, FALSE)
 	update_freelook_sight()
 
 	if(operating == 1) //emag again
@@ -240,7 +237,6 @@
 	icon_state = base_state
 
 	set_density(TRUE)
-	//air_update_turf(TRUE, TRUE)
 	update_freelook_sight()
 	sleep(10)
 

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -100,7 +100,7 @@
 */
 /obj/structure/emergency_shield/cult/barrier/proc/Toggle()
 	set_density(!density)
-	//air_update_turf(TRUE, !density)
+	zas_update_loc()
 	invisibility = initial(invisibility)
 	if(!density)
 		invisibility = INVISIBILITY_OBSERVER

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -14,15 +14,15 @@
 /obj/structure/emergency_shield/Initialize(mapload)
 	. = ..()
 	setDir(pick(GLOB.cardinals))
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/emergency_shield/Destroy()
-	update_nearby_tiles()
+	zas_update_loc()
 	. = ..()
 
 /obj/structure/emergency_shield/Move()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/emergency_shield/emp_act(severity)
 	. = ..()

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -276,16 +276,16 @@
 
 /obj/structure/foamedmetal/Initialize()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/foamedmetal/Destroy()
 	set_density(0)
-	update_nearby_tiles()
+	zas_update_loc()
 	. = ..()
 
 /obj/structure/foamedmetal/Move()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/foamedmetal/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -37,7 +37,7 @@
 /obj/structure/falsewall/Initialize()
 	. = ..()
 	color = null //Clear the color that's a mapping aid
-	update_nearby_tiles()
+	zas_update_loc()
 	set_wall_information(plating_material, reinf_material, wall_paint, stripe_paint)
 
 /obj/structure/falsewall/update_greyscale()
@@ -86,7 +86,7 @@
 		set_opacity(density)
 		opening = FALSE
 		update_appearance()
-		update_nearby_tiles()
+		zas_update_loc()
 
 /obj/structure/falsewall/zas_canpass(turf/other)
 	if(QDELETED(src))

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	var/turf/local = get_turf(loc)
 	ADD_TRAIT(local, TRAIT_FIREDOOR_STOP, TRAIT_GENERIC)
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/holosign/barrier/atmos/block_superconductivity() //Didn't used to do this, but it's "normal", and will help ease heat flow transitions with the players.
 	return TRUE
@@ -114,7 +114,7 @@
 /obj/structure/holosign/barrier/atmos/Destroy()
 	var/turf/local = get_turf(loc)
 	REMOVE_TRAIT(local, TRAIT_FIREDOOR_STOP, TRAIT_GENERIC)
-	update_nearby_tiles()
+	zas_update_loc()
 	return ..()
 
 /obj/structure/holosign/barrier/cyborg

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -37,11 +37,11 @@
 
 /obj/structure/mineral_door/Destroy()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/mineral_door/Move()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/mineral_door/Bumped(atom/movable/AM)
 	..()
@@ -101,7 +101,7 @@
 	set_density(FALSE)
 	door_opened = TRUE
 	layer = OPEN_DOOR_LAYER
-	update_nearby_tiles()
+	zas_update_loc()
 	update_appearance()
 	isSwitchingStates = FALSE
 
@@ -122,7 +122,7 @@
 	set_opacity(TRUE)
 	door_opened = FALSE
 	layer = initial(layer)
-	update_nearby_tiles()
+	zas_update_loc()
 	update_appearance()
 	isSwitchingStates = FALSE
 

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -33,7 +33,7 @@
 	. = ..()
 	if(set_dir)
 		setDir(set_dir)
-	update_nearby_tiles()
+	zas_update_loc()
 
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXIT = .proc/on_exit,
@@ -41,17 +41,17 @@
 
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/windoor_assembly/Destroy()
 	set_density(FALSE)
-	update_nearby_tiles()
+	zas_update_loc()
 	return ..()
 
 /obj/structure/windoor_assembly/Move()
-	update_nearby_tiles()
+	zas_update_loc()
 	. = ..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/windoor_assembly/update_icon_state()
 	icon_state = "[facing]_[secure ? "secure_" : ""]windoor_assembly[state]"

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -62,7 +62,7 @@
 	if(reinf && anchored)
 		state = RWINDOW_SECURE
 
-	update_nearby_tiles()
+	zas_update_loc()
 
 	if(fulltile)
 		setDir()
@@ -251,7 +251,7 @@
 
 /obj/structure/window/set_anchored(anchorvalue)
 	..()
-	//air_update_turf(TRUE, anchorvalue)
+	zas_update_loc()
 	update_nearby_icons()
 
 /obj/structure/window/proc/check_state(checked_state)
@@ -333,7 +333,7 @@
 		. += new /obj/item/shard(location)
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER
@@ -346,7 +346,7 @@
 	set_density(FALSE)
 	update_nearby_icons()
 	can_atmos_pass = CANPASS_ALWAYS //hacky-sacky
-	update_nearby_tiles()
+	zas_update_loc()
 
 	if(!fulltile)
 		var/turf/open/T = get_step(src, dir)

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -42,7 +42,7 @@
 	setDir(pick(GLOB.cardinals))
 	update_appearance()
 	if(atmosblock)
-		update_nearby_tiles()
+		zas_update_loc()
 	ConsumeTile()
 	if(!QDELETED(src)) //Consuming our tile can in rare cases cause us to del
 		AddElement(/datum/element/swabable, CELL_LINE_TABLE_BLOB, CELL_VIRUS_TABLE_GENERIC, 2, 2)
@@ -69,7 +69,7 @@
 /obj/structure/blob/Destroy()
 	if(atmosblock)
 		atmosblock = FALSE
-		update_nearby_tiles()
+		zas_update_loc()
 	if(overmind)
 		overmind.all_blobs -= src
 		overmind.blobs_legit -= src  //if it was in the legit blobs list, it isn't now

--- a/code/modules/atmospherics/ZAS/Atom.dm
+++ b/code/modules/atmospherics/ZAS/Atom.dm
@@ -1,7 +1,7 @@
 ///Tells ZAS to mark the tile the atom is in to update.
 /atom/proc/zas_update_loc()
 	var/turf/T = get_turf(src)
-	if(T.simulated)
+	if(T?.simulated)
 		SSzas.mark_for_update(get_turf(src))
 		return TRUE
 	return FALSE

--- a/code/modules/atmospherics/ZAS/Atom.dm
+++ b/code/modules/atmospherics/ZAS/Atom.dm
@@ -1,12 +1,10 @@
-//Convenience function for atoms to update turfs they occupy
-/atom/movable/proc/update_nearby_tiles()
-	for(var/turf/turf in locs)
-		if(!turf.simulated)
-			continue
-		SSzas.mark_for_update(turf)
-
-	return 1
-
+///Tells ZAS to mark the tile the atom is in to update.
+/atom/proc/zas_update_loc()
+	var/turf/T = get_turf(src)
+	if(T.simulated)
+		SSzas.mark_for_update(get_turf(src))
+		return TRUE
+	return FALSE
 
 //Returns:
 // 0 / AIR_ALLOWED - Not blocked. Air and zones can mingle with this turf as they please.

--- a/code/modules/atmospherics/ZAS/Turf.dm
+++ b/code/modules/atmospherics/ZAS/Turf.dm
@@ -7,7 +7,7 @@
 	var/z_flags = NONE
 
 /turf
-	///Does this turf need to be ran through SSzas? (SSzas.mark_for_update(turf) OR turf.update_nearby_tiles())
+	///Does this turf need to be ran through SSzas? (SSzas.mark_for_update(turf) OR turf.zas_update_loc())
 	var/needs_air_update = 0
 	///The local gas mixture of this turf. Use return_air(). This will always exist even if not in use, because GCing air contents would be too expensive.
 	var/datum/gas_mixture/air

--- a/code/modules/atmospherics/ZAS/zas_extras/inflatable.dm
+++ b/code/modules/atmospherics/ZAS/zas_extras/inflatable.dm
@@ -71,14 +71,14 @@
 
 /obj/structure/inflatable/New(location)
 	..()
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/inflatable/Initialize()
 	. = ..()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/inflatable/Destroy()
-	update_nearby_tiles()
+	zas_update_loc()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
@@ -248,7 +248,7 @@
 	state = 1
 	update_icon()
 	isSwitchingStates = 0
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/inflatable/door/proc/Close()
 	// If the inflatable is blocked, don't close
@@ -267,7 +267,7 @@
 	state = 0
 	update_icon()
 	isSwitchingStates = 0
-	update_nearby_tiles()
+	zas_update_loc()
 
 /obj/structure/inflatable/door/update_icon()
 	. = ..()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -30,6 +30,8 @@
 	//If a turf has no gas, it's safe to assume its a pure vacuum. So we should radiate heat instead of doing heat exchange.
 	if(!turf_air || turf_air.total_moles == 0)
 		radiate_heat_to_space(pipe_air, 2, 1) //the magic "2" is the surface area in square meters.
+		if(parent)
+			parent.update = TRUE
 	else
 		if(islava(local_turf))
 			environment_temperature = 5000 //Yuck

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -23,9 +23,12 @@
 	var/datum/gas_mixture/pipe_air = return_air()
 
 	var/turf/local_turf = loc
+	var/datum/gas_mixture/turf_air = loc.return_air()
 	if(!istype(local_turf))
-		CRASH("Processing HE pipe not in a")
-	if(isspaceturf(local_turf))
+		CRASH("Processing HE pipe not in a turf!")
+
+	//If a turf has no gas, it's safe to assume its a pure vacuum. So we should radiate heat instead of doing heat exchange.
+	if(!turf_air || turf_air.total_moles == 0)
 		radiate_heat_to_space(pipe_air, 2, 1) //the magic "2" is the surface area in square meters.
 	else
 		if(islava(local_turf))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Any turf that
- Has no air mixture (this should never happen but you never know)
- Has a `total_moles` count of `0`
is treated as a total vacuum for the purposes of heat exchanging pipes.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All spacestation cold loops will behave the same, and putting HE pipes on plating will no longer tank their usefulness.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog


:cl:
fix: Heat exchanging pipes are more consistent. Affecting primarily cold loops in space.
fix: Windows will now trigger ZAS updates when anchored or unanchored.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
