### PR TITLE
Fixes the contaminated setting on air alarms

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -404,7 +404,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	//Ship ambience just loops if turned on.
 	if(L.client?.prefs.toggles & SOUND_SHIP_AMBIENCE)
-		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 35, channel = CHANNEL_BUZZ))
+		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 100, channel = CHANNEL_BUZZ))
 
 /**
  * Called when an atom exits an area

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -406,7 +406,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 	//Ship ambience just loops if turned on.
 	if(L.client?.prefs.toggles & SOUND_SHIP_AMBIENCE)
-		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 100, channel = CHANNEL_BUZZ))
+		SEND_SOUND(L, sound('sound/ambience/shipambience.ogg', repeat = 1, wait = 0, volume = 35, channel = CHANNEL_BUZZ))
 
 /**
  * Called when an atom exits an area

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -25,6 +25,8 @@
 	var/list/airalarms
 	///Alarm type to count of sources. Not usable for ^ because we handle fires differently
 	var/list/active_alarms = list()
+	///All the lights in this area
+	var/list/obj/machinery/light/lights
 
 	var/lightswitch = TRUE
 	var/list/light_switches = list()
@@ -479,7 +481,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 
 ///Called by airalarms and firealarms to communicate the status of the area to relevant machines
 /area/proc/communicate_fire_alert(code)
-	for(var/obj/machinery/light/L in src)
+	for(var/obj/machinery/light/L as anything in lights)
 		L.update()
 
 	for(var/datum/listener in airalarms + firealarms + firedoors)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -517,7 +517,7 @@
 			for(var/device_id in my_area.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
-					"set_filters" = ASSORTED_GASES,
+					"set_filters" = ASSORTED_GASES - list(GAS_OXYGEN, GAS_N2),
 					"scrubbing" = 1,
 					"quicksucc" = 1
 				), signal_source)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -517,7 +517,7 @@
 			for(var/device_id in my_area.air_scrub_info)
 				send_signal(device_id, list(
 					"power" = 1,
-					"set_filters" = ASSORTED_GASES - list(GAS_OXYGEN, GAS_N2),
+					"set_filters" = ASSORTED_GASES - list(GAS_OXYGEN, GAS_NITROGEN),
 					"scrubbing" = 1,
 					"quicksucc" = 1
 				), signal_source)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -29,6 +29,7 @@
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	become_area_sensitive()
 	GLOB.human_list += src
 
 /mob/living/carbon/human/proc/setup_human_dna()

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -66,6 +66,9 @@
 	///The minimum value for the light's power in emergency mode
 	var/bulb_emergency_pow_min = 0.2
 
+	///The area this thing is in.
+	var/area/my_area = null
+
 /obj/machinery/light/Move()
 	if(status != LIGHT_BROKEN)
 		break_light_tube(TRUE)
@@ -88,6 +91,9 @@
 
 /obj/machinery/light/LateInitialize()
 	. = ..()
+	my_area = get_area(src)
+	if(my_area)
+		LAZYADD(my_area.lights, src)
 	switch(fitting)
 		if("tube")
 			if(prob(2))
@@ -98,9 +104,10 @@
 	addtimer(CALLBACK(src, .proc/update, FALSE), 0.1 SECONDS)
 
 /obj/machinery/light/Destroy()
-	var/area/local_area = get_area(src)
-	if(local_area)
+	if(my_area)
 		on = FALSE
+		LAZYREMOVE(my_area.lights, src)
+	my_area = null
 	QDEL_NULL(cell)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: "Contaminated" on air alarms no longer siphons out N2/O2
fix: Humans are now area sensitive regardless of mood config.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
