### PR TITLE
(BALANCE CHANGE) Nerfs Reinforced Glass melee armor

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -22,14 +22,6 @@
 #define WINDOW_IN_FRAME 1
 #define WINDOW_SCREWED_TO_FRAME 2
 
-//reinforced window construction states
-#define RWINDOW_FRAME_BOLTED 3
-#define RWINDOW_BARS_CUT 4
-#define RWINDOW_POPPED 5
-#define RWINDOW_BOLTS_OUT 6
-#define RWINDOW_BOLTS_HEATED 7
-#define RWINDOW_SECURE 8
-
 //airlock assembly construction states
 #define AIRLOCK_ASSEMBLY_NEEDS_WIRES 0
 #define AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS 1

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -435,7 +435,7 @@
 	icon_state = "rwindow"
 	reinf = TRUE
 	heat_resistance = 1600
-	armor = list(MELEE = 80, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
+	armor = list(MELEE = 30, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 25, BIO = 100, FIRE = 80, ACID = 100)
 	max_integrity = 75
 	explosion_block = 1
 	damage_deflection = 11
@@ -549,7 +549,7 @@
 	icon_state = "plasmawindow"
 	reinf = FALSE
 	heat_resistance = 25000
-	armor = list(MELEE = 80, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 45, BIO = 100, FIRE = 99, ACID = 100)
+	armor = list(MELEE = 60, BULLET = 5, LASER = 0, ENERGY = 0, BOMB = 45, BIO = 100, FIRE = 99, ACID = 100)
 	max_integrity = 200
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Melee armor on reinforced windows is changed from 80 to 30. Have you ever noticed that regular reinforced glass is _really_ hard to break? That's because it shared the same armor values with plasma glass!

For an example of how this will affect breaking windows, let's look at how many hits from a wielded spear a reinforced window can take.
- With the changes in this PR: 12 hits to break a window.
- In normal gameplay: **42 CONSECUTIVE HITS**

This will also allow weaker mobs like space carp to break r-windows again. This is arguably a good change, because it means more people will get killed by space wind.

Deconstructing and constructing windows has been made faster and now has less steps, and no longer is a right-click action. Constructing R-windows now goes screwdriver (anchoring) -> crowbar (prying) -> wrench (bolting), and deconstruction is the same steps in reverse. The base time for construction and deconstruction actions has been lowered to 2 seconds.

This PR also slightly changes the armor of non-reinforced plasma glass windows, so that there's more incentive to reinforce them. This won't really change gameplay at all but it did bother me.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This obviously comes down to how players and staff personally feel about the balance of the game, but it seems safe to say that currently fulltile reinforced windows are too strong. A solid window with metal reinforcements should not be more damage resistant then a vacuum tight metal airlock.

Window deconstruction times are also unusually long because they were originally intended to be increased by positive mood, which we do not have enabled.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reinforced windows are now much less resilient against melee damage and are easier to deconstruct.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
